### PR TITLE
Add LibreTorrent to 'Projects using libtorrent4j'

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ $ git checkout master
 Projects using libtorrent4j
 ==========================
 Submit a PR to add a link here.
+ - [LibreTorrent](https://gitlab.com/proninyaroslav/libretorrent)
 
 License
 ========


### PR DESCRIPTION
Hi. I migrated from `jlibtorrent` https://gitlab.com/proninyaroslav/libretorrent/commit/35cac09647baf3cf92431c5e02f7069d232f7594.