### PR TITLE
openssl build: make install -> make install_sw

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -221,7 +221,7 @@ script:
   - $run_openssl_configure
   - echo "Compiling openssl...(remove &> /dev/null to see output)"
   - make &> /dev/null
-  - make install &> /dev/null
+  - make install_sw &> /dev/null
   - cd ..
   - export OPENSSL_ROOT=$PWD/openssl
 


### PR DESCRIPTION
This speeds up considerably the make install step for OpenSSL as it does not copy all the man and doc files.