### PR TITLE
cache_size -> deprecated_cache_size

### DIFF
--- a/src/main/java/org/libtorrent4j/SettingsPack.java
+++ b/src/main/java/org/libtorrent4j/SettingsPack.java
@@ -412,7 +412,7 @@ public final class SettingsPack {
      * @return the current value
      */
     public int cacheSize() {
-        return sp.get_int(settings_pack.int_types.cache_size.swigValue());
+        return sp.get_int(settings_pack.int_types.deprecated_cache_size.swigValue());
     }
 
     /**
@@ -429,7 +429,7 @@ public final class SettingsPack {
      * @return this
      */
     public SettingsPack cacheSize(int value) {
-        sp.set_int(settings_pack.int_types.cache_size.swigValue(), value);
+        sp.set_int(settings_pack.int_types.deprecated_cache_size.swigValue(), value);
         return this;
     }
 


### PR DESCRIPTION
If you run-swig.sh on the latest libtorrent source code the int type cache_size is now deprecated_cache_size

(Don't merge unless you test it on your end and it makes sense)