### PR TITLE
Fix SIGSEGV in bdecode_node if the pointer is null

### DIFF
--- a/src/main/java/org/libtorrent4j/swig/bdecode_node.java
+++ b/src/main/java/org/libtorrent4j/swig/bdecode_node.java
@@ -57,7 +57,8 @@ public class bdecode_node {
   }
 
   public bdecode_node list_at(int i) {
-    return new bdecode_node(libtorrent_jni.bdecode_node_list_at(swigCPtr, this, i), true);
+    long cPtr = libtorrent_jni.bdecode_node_list_at(swigCPtr, this, i);
+    return (cPtr == 0) ? null : new bdecode_node(cPtr, true);
   }
 
   public long list_int_value_at(int i, long default_val) {
@@ -73,7 +74,8 @@ public class bdecode_node {
   }
 
   public bdecode_node_bdecode_node_pair dict_at_node(int i) {
-    return new bdecode_node_bdecode_node_pair(libtorrent_jni.bdecode_node_dict_at_node(swigCPtr, this, i), true);
+    long cPtr = libtorrent_jni.bdecode_node_dict_at_node(swigCPtr, this, i);
+    return (cPtr == 0) ? null : new bdecode_node_bdecode_node_pair(cPtr, true);
   }
 
   public int dict_size() {
@@ -105,23 +107,28 @@ public class bdecode_node {
   }
 
   public bdecode_node dict_find_ex(String key) {
-    return new bdecode_node(libtorrent_jni.bdecode_node_dict_find_ex(swigCPtr, this, key), true);
+    long cPtr = libtorrent_jni.bdecode_node_dict_find_ex(swigCPtr, this, key);
+    return (cPtr == 0) ? null : new bdecode_node(cPtr, true);
   }
 
   public bdecode_node dict_find_dict_ex(String key) {
-    return new bdecode_node(libtorrent_jni.bdecode_node_dict_find_dict_ex(swigCPtr, this, key), true);
+    long cPtr = libtorrent_jni.bdecode_node_dict_find_dict_ex(swigCPtr, this, key);
+    return (cPtr == 0) ? null : new bdecode_node(cPtr, true);
   }
 
   public bdecode_node dict_find_list_ex(String key) {
-    return new bdecode_node(libtorrent_jni.bdecode_node_dict_find_list_ex(swigCPtr, this, key), true);
+    long cPtr = libtorrent_jni.bdecode_node_dict_find_list_ex(swigCPtr, this, key);
+    return (cPtr == 0) ? null : new bdecode_node(cPtr, true);
   }
 
   public bdecode_node dict_find_string_ex(String key) {
-    return new bdecode_node(libtorrent_jni.bdecode_node_dict_find_string_ex(swigCPtr, this, key), true);
+    long cPtr = libtorrent_jni.bdecode_node_dict_find_string_ex(swigCPtr, this, key);
+    return (cPtr == 0) ? null : new bdecode_node(cPtr, true);
   }
 
   public bdecode_node dict_find_int_ex(String key) {
-    return new bdecode_node(libtorrent_jni.bdecode_node_dict_find_int_ex(swigCPtr, this, key), true);
+    long cPtr = libtorrent_jni.bdecode_node_dict_find_int_ex(swigCPtr, this, key);
+    return (cPtr == 0) ? null : new bdecode_node(cPtr, true);
   }
 
   public String dict_find_string_value_ex(String key, String default_value) {

--- a/src/test/java/org/libtorrent4j/BDecodeReadTest.java
+++ b/src/test/java/org/libtorrent4j/BDecodeReadTest.java
@@ -34,4 +34,20 @@ public class BDecodeReadTest {
 
         assertEquals("failed to create torrent info: " + ec.message(), ret, 0);
     }
+
+    @Test
+    public void testFind() throws IOException {
+        byte[] data = Utils.resourceBytes("test5.torrent");
+
+        byte_vector buffer = Vectors.bytes2byte_vector(data);
+        bdecode_node e = new bdecode_node();
+        error_code ec = new error_code();
+        bdecode_node.bdecode(buffer, e, ec);
+
+        assertNull(e.dict_find_list_ex("announce-list"))
+        assertNotNull(e.dict_find_dict_ex("info"))
+
+        ec.clear();
+        buffer.clear(); // prevents GC
+    }
 }


### PR DESCRIPTION
When I try to call a method like `bdecode_node::dict_find_list_ex` and if the node is not found, then the method returns a `bdecode_node` object with a null pointer inside. So, if I call any method that works with a pointer (e.g. `bdecode_node::list_size`) then it throws SIGSEGV:

```
Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0 in tid 5356 (Thread-25), pid 4773 (retorrent.debug)
Cmdline: org.proninyaroslav.libretorrent.debug
pid: 4773, tid: 5356, name: Thread-25  >>> org.proninyaroslav.libretorrent.debug <<<
      #00 pc 00000000004e01fb  /data/app/~~EkxMRlct1QKfCfnHyTjFRg==/org.proninyaroslav.libretorrent.debug-FMioUk8YZURWH9vwH05GZA==/base.apk!libtorrent4j.so (BuildId: d53f27ff86ba13ddd65ced77599f29d7f089ba06)
      #01 pc 000000000046352f  /data/app/~~EkxMRlct1QKfCfnHyTjFRg==/org.proninyaroslav.libretorrent.debug-FMioUk8YZURWH9vwH05GZA==/base.apk!libtorrent4j.so (Java_org_libtorrent4j_swig_libtorrent_1jni_bdecode_1node_1list_1size+15) (BuildId: d53f27ff86ba13ddd65ced77599f29d7f089ba06)
      #04 pc 000000000003006c  [anon:dalvik-classes19.dex extracted in memory from /data/app/~~EkxMRlct1QKfCfnHyTjFRg==/org.proninyaroslav.libretorrent.debug-FMioUk8YZURWH9vwH05GZA==/base.apk!classes19.dex] (org.libtorrent4j.swig.bdecode_node.list_size+12)
      #06 pc 000000000001456e  /data/data/org.proninyaroslav.libretorrent.debug/code_cache/.overlay/base.apk/classes12.dex (org.proninyaroslav.libretorrent.core.model.session.TorrentSessionImpl.extractTrackers+62)
      #08 pc 0000000000017732  /data/data/org.proninyaroslav.libretorrent.debug/code_cache/.overlay/base.apk/classes12.dex (org.proninyaroslav.libretorrent.core.model.session.TorrentSessionImpl.mergeTorrent+266)
      #10 pc 0000000000015692  /data/data/org.proninyaroslav.libretorrent.debug/code_cache/.overlay/base.apk/classes12.dex (org.proninyaroslav.libretorrent.core.model.session.TorrentSessionImpl.addTorrent+882)
      #12 pc 000000000000b87a  [anon:dalvik-classes6.dex extracted in memory from /data/app/~~EkxMRlct1QKfCfnHyTjFRg==/org.proninyaroslav.libretorrent.debug-FMioUk8YZURWH9vwH05GZA==/base.apk!classes6.dex] (org.proninyaroslav.libretorrent.core.model.TorrentEngine.addTorrentSync+42)
      #14 pc 000000000001714c  [anon:dalvik-classes5.dex extracted in memory from /data/app/~~EkxMRlct1QKfCfnHyTjFRg==/org.proninyaroslav.libretorrent.debug-FMioUk8YZURWH9vwH05GZA==/base.apk!classes5.dex] (org.proninyaroslav.libretorrent.ui.addtorrent.AddTorrentViewModel.lambda$addTorrent$5$org-proninyaroslav-libretorrent-ui-addtorrent-AddTorrentViewModel+20)
      #16 pc 000000000001539c  [anon:dalvik-classes5.dex extracted in memory from /data/app/~~EkxMRlct1QKfCfnHyTjFRg==/org.proninyaroslav.libretorrent.debug-FMioUk8YZURWH9vwH05GZA==/base.apk!classes5.dex] (org.proninyaroslav.libretorrent.ui.addtorrent.AddTorrentViewModel$$ExternalSyntheticLambda5.run+12)
```

The solution is to check the pointer and return null `bdecode_node` if the pointer is null, for methods `dict_find_*_ex`, `list_at`, `dict_at_node`.